### PR TITLE
Multi certificate support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /vendor
 handler.zip
-lkp_*
-lambda_*
+/lkp_*
+/lambda_*

--- a/ci/e2e.bash
+++ b/ci/e2e.bash
@@ -23,15 +23,15 @@ S3_OBJVER=$(aws s3api head-object --bucket $S3_BUCKET --key $S3_KEY --query Vers
 ./dl/sshello &
 sleep 1
 ./lkp_linux_amd64 ssh exec --kms-key $AWS_ACCOUNT_ID:alias/LastKeypair --instance-arn abcdef -- -o StrictHostKeyChecking=no -o LogLevel=QUIET -p 2222 -o HostName=localhost travis@target | tee out.log
-diff out.log ci/expected-output.txt
+diff -w out.log ci/expected-output.txt
 
 ./lkp_linux_amd64 ssh exec --instance-arn defghi --dry-run -- -o StrictHostKeyChecking=no -o LogLevel=QUIET -p 2222 | tee out.log
-diff out.log ci/expected-output-jumpbox.txt
-diff ~/.lkp/tmp/defghi/sshconf ci/expected-output-jumpbox-sshconf.txt
+diff -w out.log ci/expected-output-jumpbox.txt
+diff -w ~/.lkp/tmp/defghi/sshconf ci/expected-output-jumpbox-sshconf.txt
 
 VOUCHER=$(./lkp_linux_amd64 adv vouch --vouchee aidan --context moo)
 ./lkp_linux_amd64 ssh exec --instance-arn defghi --voucher $VOUCHER --dry-run -- -o StrictHostKeyChecking=no -o LogLevel=QUIET -p 2222 travis@localhost | tee out.log
-diff out.log ci/expected-output-vouched.txt
+diff -w out.log ci/expected-output-vouched.txt
 
 # openssl aes-256-cbc -pass "pass:$CI_SSH_PASSPHRASE" -in ci/ec2-ssh-key.enc -out ci/ec2-ssh-key -d -a
 # chmod 0600 ci/ec2-ssh-key

--- a/ci/expected-output-jumpbox-sshconf.txt
+++ b/ci/expected-output-jumpbox-sshconf.txt
@@ -15,4 +15,4 @@ Host target
   User ec2-user
   HostName 78.65.43.21
   ProxyJump jump0
-  
+

--- a/ci/expected-output-jumpbox-sshconf.txt
+++ b/ci/expected-output-jumpbox-sshconf.txt
@@ -15,3 +15,4 @@ Host target
   User ec2-user
   HostName 78.65.43.21
   ProxyJump jump0
+  

--- a/ci/expected-output-jumpbox-sshconf.txt
+++ b/ci/expected-output-jumpbox-sshconf.txt
@@ -7,7 +7,6 @@ Host jump0
   CertificateFile /home/travis/.lkp/tmp/12.34.56.78/id_rsa-cert.pub
   User ec2-user
 
-
 Host target
   HostKeyAlias defghi
   IdentityFile /home/travis/.lkp/id_rsa

--- a/ci/expected-output-jumpbox-sshconf.txt
+++ b/ci/expected-output-jumpbox-sshconf.txt
@@ -4,7 +4,7 @@ Host jump0
   HostName 12.34.56.78
   HostKeyAlias 12.34.56.78
   IdentityFile /home/travis/.lkp/id_rsa
-  CertificateFile /home/travis/.lkp/id_rsa-cert.pub
+  CertificateFile /home/travis/.lkp/tmp/12.34.56.78/id_rsa-cert.pub
   User ec2-user
 
 Host target
@@ -14,4 +14,3 @@ Host target
   User ec2-user
   HostName 78.65.43.21
   ProxyJump jump0
-

--- a/ci/expected-output-jumpbox-sshconf.txt
+++ b/ci/expected-output-jumpbox-sshconf.txt
@@ -7,6 +7,7 @@ Host jump0
   CertificateFile /home/travis/.lkp/tmp/12.34.56.78/id_rsa-cert.pub
   User ec2-user
 
+
 Host target
   HostKeyAlias defghi
   IdentityFile /home/travis/.lkp/id_rsa

--- a/docs/access-policy.md
+++ b/docs/access-policy.md
@@ -1,13 +1,13 @@
 # LastKeypair Access Control Policies
 
-Sometimes you don't want to grant all authenticated users access to all instances 
-in your AWS account. You might work on isolated teams, you might grant third 
-parties access to selected machines or your company might require at least two 
-people to sign off on access to particularly sensitive machines. Maybe you just 
-want to mandate a work-life balance and disable SSH access for people not 
+Sometimes you don't want to grant all authenticated users access to all instances
+in your AWS account. You might work on isolated teams, you might grant third
+parties access to selected machines or your company might require at least two
+people to sign off on access to particularly sensitive machines. Maybe you just
+want to mandate a work-life balance and disable SSH access for people not
 on-call after 5PM.
 
-LastKeypair supports these use-cases with access policies. Rather than try to 
+LastKeypair supports these use-cases with access policies. Rather than try to
 shoehorn this into some IAM policy monstrosity - or worse yet, make you learn
 another cryptic rules-engine JSON schema - we have opted to factor out authorisation
 into a separate Lambda function.
@@ -15,20 +15,20 @@ into a separate Lambda function.
 If you specify an `AUTHORIZATION_LAMBDA` environment variable, LKP will execute
 that Lambda function in order to determine if a user is authorised to SSH into
 their requested instance. You are free to structure your Lambda function however
-you please. 
+you please.
 
-The format of the Lambda's request parameters and the expected response are 
-documented in Typescript notation. 
+The format of the Lambda's request parameters and the expected response are
+documented in Typescript notation.
 
 ```typescript
 interface LkpIdentity {
     Name?: string; // IAM username - not set for assumed roles (e.g. SAML users)
     Id: string; // IAM (role/user) unique ID, equal to ${aws:userid} IAM policy variable
     Account: string; // AWS numeric account ID containing user
-    Type: "User" | "AssumedRole" | "FederatedUser"; // type of user 
+    Type: "User" | "AssumedRole" | "FederatedUser"; // type of user
 }
 
-type LkpVoucher = LkpIdentity & { 
+type LkpVoucher = LkpIdentity & {
     Vouchee: string; // free-form identifier of vouched user
     Context: string; // free-form identifier, could be e.g. instance arn
 };
@@ -46,12 +46,14 @@ interface LkpUserCertAuthorizationResponse {
     Principals: string[]; // LKP uses instance ARNs as principals for trusted hosts
                           // if this key is absent, it will default to permitting
                           // the requested RemoteInstanceArn
-    Jumpboxes?: { 
+    Jumpboxes?: {
         Address: string; // ip/domain that user should use as bastion host
         User: string; // linux user on jumpbox
-        HostKeyAlias?: string; // you might return an IP in the Address field, but
-                               // the jumpbox has a different has a different
-                               // principal in its host cert. defaults to Address
+        HostKeyAlias?: string; // you might return an IP in the Address field, but the jumpbox has a different has a different principal in its host cert. defaults to Address
+        CertificateOptions?: { // as per https://man.openbsd.org/ssh-keygen#O
+            ForceCommand?: string;
+            SourceAddress?: string;
+        };
     }[];
     TargetAddress?: string; // the IP address of the instance to connect to. this is
                             // necessary to enable transparent ssh client operation
@@ -71,8 +73,8 @@ interface LkpHostCertAuthorizationRequest {
 interface LkpHostCertAuthorizationResponse {
     Authorized: boolean;
     KeyId?: string; // defaults to HostInstanceArn if not provided
-    Principals: string[]; // LKP uses instance ARNs as principals for trusted hosts. 
-                          // additional principals are useful for bastion box domain 
+    Principals: string[]; // LKP uses instance ARNs as principals for trusted hosts.
+                          // additional principals are useful for bastion box domain
                           // names, etc
 }
 
@@ -90,11 +92,11 @@ exports.handler = function(event, context, callback) {
     // sneaky and create IAM users with the same name as us. we _could_ use IAM unique IDs
     // but in this case we'd prefer to check (acctID, username) tuples.
     var isMainAccount = event.From.Account === '9876543210';
-    
+
     var now = new Date();
     var hour = now.getUTCHours();
     var authorized = function() { callback({ authorized: true }) };
-    
+
     if (isMainAccount && event.Kind === "LkpHostCertAuthorizationRequest") authorized();
 
     if (isMainAccount && event.From.Name === 'aidan.steele@glassechidna.com.au') authorized(); // aidan is all powerful
@@ -102,7 +104,7 @@ exports.handler = function(event, context, callback) {
     if (isMainAccount && event.From.Name === 'benjamin.dobell@glassechidna.com.au') {
         if (hour >= 9 && hour < 17) authorized(); // ben usually only has access during work hours
     }
-    
+
     if (event.From.Account === '01234567890') { // aws account id of 3rd-party support provider
         if (hour < 9 || hour >= 17) authorized(); // our trusted partner is allowed in outside of work hours
     }

--- a/pkg/lastkeypair/authorizer.go
+++ b/pkg/lastkeypair/authorizer.go
@@ -36,12 +36,7 @@ type LkpUserCertAuthorizationResponse struct {
 	Principals []string
 	Jumpboxes  []Jumpbox `json:",omitempty"`
 	TargetAddress string `json:",omitempty"`
-	CertificateOptions struct {
-		ForceCommand  *string `json:",omitempty"`
-		SourceAddress *string `json:",omitempty"`
-		PermitPortForwarding bool
-		PermitX11Forwarding bool
-	}
+	CertificateOptions *CertificateOptions
 }
 
 type LkpHostCertAuthorizationRequest struct {
@@ -135,18 +130,9 @@ func (a *AuthorizationLambda) DoUserReq(userReq UserCertReqJson) (*LkpUserCertAu
 		return nil, errors.Wrap(err, "invoking user cert authorisation lambda")
 	}
 
-	jumpPrincipals := []string{}
-	for idx := range authResp.Jumpboxes {
-		j := &authResp.Jumpboxes[idx]
-		if len(j.HostKeyAlias) == 0 {
-			j.HostKeyAlias = j.Address
-		}
-		jumpPrincipals = append(jumpPrincipals, j.HostKeyAlias)
-	}
-
 	// if the lambda's response is missing the "Principals" key, default to the requested instance
 	if authResp.Principals == nil {
-		authResp.Principals = append(jumpPrincipals, p.RemoteInstanceArn)
+		authResp.Principals = []string{p.RemoteInstanceArn}
 	}
 
 	return &authResp, nil

--- a/pkg/lastkeypair/lambda.go
+++ b/pkg/lastkeypair/lambda.go
@@ -170,6 +170,37 @@ func DoHostCertReq(req HostCertReqJson, config LambdaConfig) (*HostCertRespJson,
 	return &resp, nil
 }
 
+func GenerateSshPermissions(options *CertificateOptions) ssh.Permissions {
+	var SshPermissions = ssh.Permissions{
+		CriticalOptions: map[string]string{},
+		Extensions: map[string]string{
+			"permit-X11-forwarding":   "",
+			"permit-agent-forwarding": "",
+			"permit-port-forwarding":  "",
+			"permit-pty":              "",
+			"permit-user-rc":          "",
+		},
+	}
+
+	if options.ForceCommand != nil {
+		SshPermissions.Extensions["force-command"] = *options.ForceCommand
+	}
+	if options.SourceAddress != nil {
+		SshPermissions.Extensions["source-address"] = *options.SourceAddress
+	}
+	if options.PermitX11Forwarding == false {
+		delete(SshPermissions.Extensions, "permit-X11-forwarding")
+	}
+	if options.PermitAgentForwarding == false {
+		delete(SshPermissions.Extensions, "permit-agent-forwarding")
+	}
+	if options.PermitPortForwarding == false {
+		delete(SshPermissions.Extensions, "permit-port-forwarding")
+	}
+
+	return SshPermissions
+}
+
 func DoUserCertReq(req UserCertReqJson, config LambdaConfig) (*UserCertRespJson, error) {
 	sess := LambdaAwsSession()
 
@@ -201,20 +232,7 @@ func DoUserCertReq(req UserCertReqJson, config LambdaConfig) (*UserCertRespJson,
 		return nil, errors.New(errorMessage)
 	}
 
-	permissions := DefaultSshPermissions
-	if auth.CertificateOptions.ForceCommand != nil {
-		permissions.Extensions["force-command"] = *auth.CertificateOptions.ForceCommand
-	}
-	if auth.CertificateOptions.SourceAddress != nil {
-		permissions.Extensions["source-address"] = *auth.CertificateOptions.SourceAddress
-	}
-	if auth.CertificateOptions.PermitPortForwarding == false {
-		delete(permissions.Extensions, "permit-port-forwarding")
-	}
-	if auth.CertificateOptions.PermitX11Forwarding == false {
-		delete(permissions.Extensions, "permit-X11-forwarding")
-	}
-
+	SshPermissions := GenerateSshPermissions(auth.CertificateOptions)
 
 	signed, err := SignSsh(
 		config.CaKeyBytes,
@@ -222,13 +240,38 @@ func DoUserCertReq(req UserCertReqJson, config LambdaConfig) (*UserCertRespJson,
 		[]byte(req.PublicKey),
 		ssh.UserCert,
 		uint64(time.Now().Unix() + config.ValidityDuration),
-		DefaultSshPermissions,
+		SshPermissions,
 		identity,
 		auth.Principals,
 	)
 
+	for idx := range auth.Jumpboxes {
+		j := &auth.Jumpboxes[idx]
+		if len(j.HostKeyAlias) == 0 {
+			j.HostKeyAlias = j.Address
+		}
+		if len(j.Principals) == 0 {
+			j.Principals = append(j.Principals, j.Address)
+		}
+		jSshPermissions := GenerateSshPermissions(j.CertificateOptions)
+		jSigned, jErr := SignSsh(
+			config.CaKeyBytes,
+			config.CaKeyPassphraseBytes,
+			[]byte(req.PublicKey),
+			ssh.UserCert,
+			uint64(time.Now().Unix() + config.ValidityDuration),
+			jSshPermissions,
+			identity,
+			j.Principals,
+		)
+		j.SignedPublicKey = *jSigned
+		if jErr != nil {
+			return nil, errors.Wrap(err, "error signing ssh key for jumphost")
+		}
+	}
+
 	if err != nil {
-		return nil, errors.Wrap(err, "signing ssh key")
+		return nil, errors.Wrap(err, "error signing ssh key")
 	}
 
 	expiry := time.Now().Add(time.Duration(config.ValidityDuration) * time.Second)

--- a/pkg/lastkeypair/lambda.go
+++ b/pkg/lastkeypair/lambda.go
@@ -181,21 +181,22 @@ func GenerateSshPermissions(options *CertificateOptions) ssh.Permissions {
 			"permit-user-rc":          "",
 		},
 	}
-
-	if options.ForceCommand != nil {
-		SshPermissions.Extensions["force-command"] = *options.ForceCommand
-	}
-	if options.SourceAddress != nil {
-		SshPermissions.Extensions["source-address"] = *options.SourceAddress
-	}
-	if options.PermitX11Forwarding == false {
-		delete(SshPermissions.Extensions, "permit-X11-forwarding")
-	}
-	if options.PermitAgentForwarding == false {
-		delete(SshPermissions.Extensions, "permit-agent-forwarding")
-	}
-	if options.PermitPortForwarding == false {
-		delete(SshPermissions.Extensions, "permit-port-forwarding")
+	if options != nil {
+		if options.ForceCommand != nil {
+			SshPermissions.Extensions["force-command"] = *options.ForceCommand
+		}
+		if options.SourceAddress != nil {
+			SshPermissions.Extensions["source-address"] = *options.SourceAddress
+		}
+		if options.PermitX11Forwarding == false {
+			delete(SshPermissions.Extensions, "permit-X11-forwarding")
+		}
+		if options.PermitAgentForwarding == false {
+			delete(SshPermissions.Extensions, "permit-agent-forwarding")
+		}
+		if options.PermitPortForwarding == false {
+			delete(SshPermissions.Extensions, "permit-port-forwarding")
+		}
 	}
 
 	return SshPermissions

--- a/pkg/lastkeypair/lambda_req_resp.go
+++ b/pkg/lastkeypair/lambda_req_resp.go
@@ -26,6 +26,17 @@ type Jumpbox struct {
 	Address    string
 	User       string
 	HostKeyAlias string
+	Principals []string
+	SignedPublicKey string
+	CertificateOptions *CertificateOptions
+}
+
+type CertificateOptions struct {
+	ForceCommand  *string `json:",omitempty"`
+	SourceAddress *string `json:",omitempty"`
+	PermitX11Forwarding bool
+	PermitAgentForwarding bool
+	PermitPortForwarding bool
 }
 
 type HostCertRespJson struct {


### PR DESCRIPTION
- Fixed recursive .gitignore
- Updated Access Control doc
- Move CertificateOptions to it's own type
- Added SSH permissions generator function
- Added support for multiple certificates in CLI filesystem
- A certificate is now generated per jumphost in Auth Lambda response